### PR TITLE
Tweaked the interaction with the clojar function

### DIFF
--- a/clojars.el
+++ b/clojars.el
@@ -56,8 +56,13 @@
     (deferred:nextc it
       (lambda (response)
         (let ((results (cdr (assoc 'results (request-response-data response)))))
-          (kill-new (completing-read "Results: "
-                                     (mapcar 'clojars-jar-result results))))))))
+	  (if (= 0 (length results))
+	      (message "No clojars found with that name")
+	    (progn
+	      (kill-new (completing-read "Results [TAB to complete]: "
+					 (mapcar 'clojars-jar-result results)
+					 nil 'confirm-after-completion))
+	      (message "You've copied: %s clojar" (car kill-ring)))))))))
 
 (provide 'clojars)
 


### PR DESCRIPTION
When the user searches for a non existing clojar it'll return a message
telling them that nothing was found. I've decided to add this because I
perceived the 'mute'/non-message that something is broken with my setup.

I then added the string **[TAB to complete]** because I felt that it's
helpful to show me that there are some results... and that I should pick
one...

Also added the confirmation option to completing-read so that the user
truly does confirm the choice they've made.

And finally, I've added a message telling the user that they've copied
the clojar name into the kill-ring. I found the previous behaviour a bit
puzzling/confusing. As in: "Did I do anything there?", "What just
happened?"... This approach is a bit 'hand-holdy'.

What do you think?